### PR TITLE
Examples adapted to work with new Gateway infrastracture

### DIFF
--- a/example_ios.py
+++ b/example_ios.py
@@ -9,16 +9,28 @@
 import websocket # websocket-client https://github.com/websocket-client/websocket-client
 import json      # default supported by python
 import uuid      # for generating unique ids in a easy way, part of the inbuilt python packages
+import ssl
 
 MAC_AUTH = # SET MAC STRING HERE (see: https://wiki.ros.org/rosauth)
 
 if __name__ == "__main__":
-    connection_ip = "127.0.0.1" # Loopback localhost address, assuming running in same computer
-    connection_port = 9091
-    connection_uri = "ws://" + connection_ip + ":" + str(connection_port)
+    connection_ip = "192.168.100.100" # Loopback localhost address, assuming running in same computer
+    connection_port = 80              # If SSL is activated on the controller use port 443
+    connection_protocol = "ws://"     # If SSL is activated use protocol 'wss://'
+
+    connection_uri = connection_protocol + connection_ip + ":" + str(connection_port) + '/dnb-rosbridge'
+
+    ### NO SSL ###
+    ws = websocket.create_connection(connection_uri, timeout=10)
+
+    ### SSL activated ########
+    # Uncomment the following code if you are using a self signed certificate on the controller
+    # **NOT RECOMMENDED FOR PRODUCTION USAGE.** sslopt dict disables certificate verification.
+    #ssl_options = {"cert_reqs": ssl.CERT_NONE}
 
     # Synchronous connection for this example
-    ws = websocket.create_connection(connection_uri, timeout=1)
+    #ws = websocket.create_connection(connection_uri, sslopt=ssl_options, timeout=10)
+    ### End: SSL activated ###
 
     # Auth service call needs to be set directly on the first request after established connection
     auth_service = {

--- a/example_move_robot.py
+++ b/example_move_robot.py
@@ -6,6 +6,8 @@
 import websocket # websocket-client https://github.com/websocket-client/websocket-client
 import json      # default supported by python
 
+MAC_AUTH = # SET MAC STRING HERE (see: https://wiki.ros.org/rosauth)
+
 # Returns a joint motion command with two waypoints (two joint positions)
 def create_move_command():
     payload = {
@@ -89,9 +91,11 @@ def on_open(ws):
 
 
 if __name__ == "__main__":
-    connection_ip = "127.0.0.1" # Loopback localhost address, assuming running in same computer
-    connection_port = 9091
-    connection_uri = "ws://" + connection_ip + ":" + str(connection_port)
+    connection_ip = "192.168.100.100" # Loopback localhost address, assuming running in same computer
+    connection_port = 80              # If SSL is activated on the controller use port 443
+    connection_protocol = "ws://"     # If SSL is activated use protocol 'wss://'
+
+    connection_uri = connection_protocol + connection_ip + ":" + str(connection_port) + '/dnb-rosbridge'
 
     websocket.enableTrace(False)
     ws = websocket.WebSocketApp(connection_uri,
@@ -100,4 +104,15 @@ if __name__ == "__main__":
             on_error=on_error,
             on_close=on_close)
 
+    ### NO SSL ###
     ws.run_forever()
+
+    ### SSL activated ########
+    # Uncomment the following code if you are using a self signed certificate on the controller
+    # **NOT RECOMMENDED FOR PRODUCTION USAGE.** sslopt dict disables certificate verification.
+    #ssl_options = {"cert_reqs": ssl.CERT_NONE}
+
+    # Synchronous connection for this example
+    #ws.run_forever(sslopt=ssl_options)
+    ### End: SSL activated ###
+

--- a/example_read_robot_positions.py
+++ b/example_read_robot_positions.py
@@ -52,9 +52,11 @@ def on_open(ws):
     ws.send(json.dumps(msg_subscribe_joint_command)) # Send command to AnyRobot Interface
 
 if __name__ == "__main__":
-    connection_ip = "127.0.0.1" # Loopback localhost address, assuming running in same computer
-    connection_port = 9091
-    connection_uri = "ws://" + connection_ip + ":" + str(connection_port)
+    connection_ip = "192.168.100.100" # Loopback localhost address, assuming running in same computer
+    connection_port = 80              # If SSL is activated on the controller use port 443
+    connection_protocol = "ws://"     # If SSL is activated use protocol 'wss://'
+
+    connection_uri = connection_protocol + connection_ip + ":" + str(connection_port) + '/dnb-rosbridge'
 
     websocket.enableTrace(False)
     ws = websocket.WebSocketApp(connection_uri,
@@ -63,4 +65,14 @@ if __name__ == "__main__":
             on_error=on_error,
             on_close=on_close)
 
+    ### NO SSL ###
     ws.run_forever()
+
+    ### SSL activated ########
+    # Uncomment the following code if you are using a self signed certificate on the controller
+    # **NOT RECOMMENDED FOR PRODUCTION USAGE.** sslopt dict disables certificate verification.
+    #ssl_options = {"cert_reqs": ssl.CERT_NONE}
+
+    # Synchronous connection for this example
+    #ws.run_forever(sslopt=ssl_options)
+    ### End: SSL activated ###


### PR DESCRIPTION
Additional added examples in code on how to work use self signed certificates for testing. In production we shouldn't disabled verification its a security risk and can lead to MITM attacks.